### PR TITLE
GitHub Action to just test on macOS, Ubuntu, and Windows

### DIFF
--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -1,0 +1,20 @@
+name: just_test
+
+on: [pull_request, push]
+
+jobs:
+  just_test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: brew install just || choco install just || sudo apt install just
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: python -m pip install pipenv || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      # - run: python -m pipenv install
+      - run: just test

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -10,11 +10,12 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: brew install just || choco install just || sudo apt install just
+      - run: choco install just || brew install just || sudo apt-get update && sudo apt install just
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
-      - run: python -m pip install pipenv || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      # - run: python -m pipenv install
+      - run: pip install --upgrade pip
+      # - run: python -m pip install pipenv || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      - run: python -m pipenv install
       - run: just test

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -5,15 +5,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - if: ${{ startsWith(matrix.os, 'macos') }}
+        run: brew install just
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
         run: sudo snap install --edge --classic just
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install just
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        run: brew install just
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -10,12 +10,28 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - run: choco install just || brew install just || sudo apt-get update && sudo apt install just
+      - if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        run: |
+          snap --version || true
+          crate --version || true
+          makedeb --version || true
+          mist --version || true
+          just --version || true
+          sudo apt-get update
+          sudo apt install makedeb
+          sudo apt install mist
+          makedeb just || true
+          mist just || true
+          sudo apt install just || true
+      - if: ${{ startsWith(matrix.os, 'windows') }}
+        run: choco install just
+      - if: ${{ startsWith(matrix.os, 'macos') }}
+        run: brew install just
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: pip install --upgrade pip
-      # - run: python -m pip install pipenv || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
+      - run: python -m pip install pipenv  # || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
       - run: python -m pipenv install
       - run: just test

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -1,7 +1,5 @@
 name: just_test
-
 on: [pull_request, push]
-
 jobs:
   just_test:
     strategy:
@@ -21,6 +19,5 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install --upgrade pip
-      - run: python -m pip install pipenv  # || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      # - run: python -m pipenv install
+      - run: pip install pipenv
       - run: just test

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: snap install --edge --classic just
+        run: sudo snap install --edge --classic just
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install just
       - if: ${{ startsWith(matrix.os, 'macos') }}

--- a/.github/workflows/just_test.yml
+++ b/.github/workflows/just_test.yml
@@ -11,18 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - if: ${{ startsWith(matrix.os, 'ubuntu') }}
-        run: |
-          snap --version || true
-          crate --version || true
-          makedeb --version || true
-          mist --version || true
-          just --version || true
-          sudo apt-get update
-          sudo apt install makedeb
-          sudo apt install mist
-          makedeb just || true
-          mist just || true
-          sudo apt install just || true
+        run: snap install --edge --classic just
       - if: ${{ startsWith(matrix.os, 'windows') }}
         run: choco install just
       - if: ${{ startsWith(matrix.os, 'macos') }}
@@ -33,5 +22,5 @@ jobs:
           python-version: 3.x
       - run: pip install --upgrade pip
       - run: python -m pip install pipenv  # || curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
-      - run: python -m pipenv install
+      # - run: python -m pipenv install
       - run: just test


### PR DESCRIPTION
Developers may be interested to run the same `just` commands that they use locally on continuous integration platforms such GitHub Actions.  Every time that a contributor creates a pull request, `just test` will be run on the three major operating systems to provide feedback to both the contributor and reviewers that tests are passing.

Test results: https://github.com/cclauss/django-microapi/actions
;-) macOS just worked out-of-the-box ;-)

![image](https://github.com/toastdriven/django-microapi/assets/3709715/3390f062-25d2-4108-93de-caaf3835542c)
